### PR TITLE
feat: add unwrap-tool-node-in-agent codemod

### DIFF
--- a/codemods/unwrap-tool-node-in-agent/README.md
+++ b/codemods/unwrap-tool-node-in-agent/README.md
@@ -1,0 +1,55 @@
+# unwrap-tool-node-in-agent
+
+This codemod transforms `tools=ToolNode(ARG)` to `tools=ARG` in `create_agent` and `create_react_agent` calls for LangGraph v1 migration.
+
+## Summary
+
+In LangGraph v1, `create_agent(...)` and `create_react_agent(...)` no longer accept `ToolNode` instances for the `tools` parameter; they must receive a list of tools directly.
+
+## Detection Criteria
+
+- Find calls to `create_agent(...)` or `create_react_agent(...)`
+- Within those calls, find `tools=ToolNode(ARG)` (including qualified `langgraph.prebuilt.ToolNode`)
+- Confirm `ToolNode` is used as the value of the `tools` keyword
+- Only transform when `ToolNode(...)` wraps a single argument
+
+## Transformation Logic
+
+1. Replace `tools=ToolNode(ARG)` with `tools=ARG`
+2. If `ToolNode` becomes unused in imports, remove it from the import list
+
+## Before
+
+```python
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+agent = create_react_agent(model="gpt-4o", tools=ToolNode([check_weather, search_web]))
+```
+
+## After
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(model="gpt-4o", tools=[check_weather, search_web])
+```
+
+## Edge Cases
+
+- **Multiple args/kwargs**: If `ToolNode(...)` has multiple arguments (e.g., `ToolNode([tools], handle_tool_errors=True)`), the transformation is skipped as this likely indicates custom error handling or configuration
+- **Qualified names**: Handles both `ToolNode(...)` and `langgraph.prebuilt.ToolNode(...)`
+- **Import cleanup**: Only removes `ToolNode` from imports if it's no longer used elsewhere in the file
+
+## Running the Codemod
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run tests
+pnpm test
+
+# Run the codemod on a target directory
+npx codemod workflow run -w ./workflow.yaml -t /path/to/target
+```
+

--- a/codemods/unwrap-tool-node-in-agent/codemod.yaml
+++ b/codemods/unwrap-tool-node-in-agent/codemod.yaml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 name: "unwrap-tool-node-in-agent"
 version: "0.1.0"
 description: "Transform tools=ToolNode(ARG) to tools=ARG in create_agent/create_react_agent calls"
-author: "Author <author@example.com>"
+author: "Alex Bit <alex@codemod.com>"
 license: "MIT"
 workflow: "workflow.yaml"
 category: "migration"
@@ -11,9 +11,8 @@ category: "migration"
 targets:
   languages: ["python"]
 
-keywords: ["langgraph", "langchain", "migration", "ToolNode"]
+keywords: ["langgraph", "langchain", "migration", "ToolNode", "create_agent", "create_react_agent"]
 
 registry:
   access: "public"
   visibility: "public"
-

--- a/codemods/unwrap-tool-node-in-agent/codemod.yaml
+++ b/codemods/unwrap-tool-node-in-agent/codemod.yaml
@@ -1,0 +1,19 @@
+schema_version: "1.0"
+
+name: "unwrap-tool-node-in-agent"
+version: "0.1.0"
+description: "Transform tools=ToolNode(ARG) to tools=ARG in create_agent/create_react_agent calls"
+author: "Author <author@example.com>"
+license: "MIT"
+workflow: "workflow.yaml"
+category: "migration"
+
+targets:
+  languages: ["python"]
+
+keywords: ["langgraph", "langchain", "migration", "ToolNode"]
+
+registry:
+  access: "public"
+  visibility: "public"
+

--- a/codemods/unwrap-tool-node-in-agent/package.json
+++ b/codemods/unwrap-tool-node-in-agent/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "unwrap-tool-node-in-agent",
+	"version": "0.1.0",
+	"description": "Transform tools=ToolNode(ARG) to tools=ARG in create_agent/create_react_agent calls",
+	"type": "module",
+	"devDependencies": {
+		"@codemod.com/jssg-types": "^1.0.3",
+		"typescript": "^5.8.3"
+	},
+	"scripts": {
+		"test": "npx codemod@latest jssg test -l python ./scripts/codemod.ts",
+		"check-types": "npx tsc --noEmit"
+	}
+}
+

--- a/codemods/unwrap-tool-node-in-agent/scripts/codemod.ts
+++ b/codemods/unwrap-tool-node-in-agent/scripts/codemod.ts
@@ -1,0 +1,349 @@
+import type { Edit, SgNode, SgRoot } from "codemod:ast-grep";
+import type Python from "codemod:ast-grep/langs/python";
+
+/**
+ * Codemod: unwrap-tool-node-in-agent
+ *
+ * Transforms `tools=ToolNode(ARG)` to `tools=ARG` in create_agent/create_react_agent calls.
+ *
+ * Detection criteria:
+ * - Find calls to create_agent(...) or create_react_agent(...)
+ * - Within those calls, find tools=ToolNode(ARG) (including qualified langgraph.prebuilt.ToolNode)
+ * - Only transform when ToolNode wraps a single argument
+ *
+ * Transformation:
+ * 1. Replace tools=ToolNode(ARG) with tools=ARG
+ * 2. If ToolNode becomes unused in imports, remove it from the import list
+ */
+
+/**
+ * Check if a call node is calling ToolNode (either direct identifier or qualified attribute)
+ */
+function isToolNodeCall(callNode: SgNode<Python>): boolean {
+	const func = callNode.field("function");
+	if (!func) return false;
+
+	// Direct identifier: ToolNode(...)
+	if (func.is("identifier") && func.text() === "ToolNode") {
+		return true;
+	}
+
+	// Qualified attribute: langgraph.prebuilt.ToolNode(...)
+	if (func.is("attribute")) {
+		const attrName = func.field("attribute");
+		if (attrName && attrName.text() === "ToolNode") {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Check if a call node is calling create_agent or create_react_agent
+ */
+function isAgentCreationCall(callNode: SgNode<Python>): boolean {
+	const func = callNode.field("function");
+	if (!func) return false;
+
+	const targetFunctions = ["create_agent", "create_react_agent"];
+
+	// Direct identifier
+	if (func.is("identifier") && targetFunctions.includes(func.text())) {
+		return true;
+	}
+
+	// Qualified attribute: module.create_agent(...)
+	if (func.is("attribute")) {
+		const attrName = func.field("attribute");
+		if (attrName && targetFunctions.includes(attrName.text())) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Check if ToolNode call has exactly one positional argument (no kwargs)
+ */
+function hasSingleArgument(toolNodeCall: SgNode<Python>): boolean {
+	const argList = toolNodeCall.field("arguments");
+	if (!argList) return false;
+
+	// Get all children that are actual arguments (not punctuation)
+	const args = argList.children().filter((child) => {
+		const kind = child.kind();
+		// Filter out punctuation tokens
+		return kind !== "(" && kind !== ")" && kind !== ",";
+	});
+
+	// Should have exactly 1 argument, and it should NOT be a keyword_argument
+	if (args.length !== 1) return false;
+
+	const singleArg = args[0];
+	// Skip if it's a keyword argument (like handle_tool_errors=True)
+	if (singleArg?.is("keyword_argument")) return false;
+
+	return true;
+}
+
+/**
+ * Get the single argument from a ToolNode call
+ */
+function getSingleArgument(toolNodeCall: SgNode<Python>): SgNode<Python> | null {
+	const argList = toolNodeCall.field("arguments");
+	if (!argList) return null;
+
+	const args = argList.children().filter((child) => {
+		const kind = child.kind();
+		return kind !== "(" && kind !== ")" && kind !== ",";
+	});
+
+	return args.length === 1 ? args[0] ?? null : null;
+}
+
+/**
+ * Find keyword argument with name "tools" that has ToolNode as its value
+ */
+function findToolsArgWithToolNode(
+	agentCall: SgNode<Python>,
+): { kwArg: SgNode<Python>; toolNodeCall: SgNode<Python> } | null {
+	const argList = agentCall.field("arguments");
+	if (!argList) return null;
+
+	// Find keyword_argument with name="tools"
+	const toolsKwArgs = argList.findAll({
+		rule: {
+			kind: "keyword_argument",
+			has: {
+				field: "name",
+				kind: "identifier",
+				regex: "^tools$",
+			},
+		},
+	});
+
+	for (const kwArg of toolsKwArgs) {
+		// Get the value field of the keyword argument
+		const value = kwArg.field("value");
+		if (!value || !value.is("call")) continue;
+
+		// Check if the call is to ToolNode
+		if (isToolNodeCall(value) && hasSingleArgument(value)) {
+			return { kwArg, toolNodeCall: value };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Find all ToolNode usages in the file (to determine if import can be removed)
+ */
+function countToolNodeUsages(rootNode: SgNode<Python>): number {
+	// Find all call expressions where function is ToolNode
+	const directCalls = rootNode.findAll({
+		rule: {
+			kind: "call",
+			has: {
+				field: "function",
+				kind: "identifier",
+				regex: "^ToolNode$",
+			},
+		},
+	});
+
+	return directCalls.length;
+}
+
+/**
+ * Find and create edit to remove ToolNode from imports if unused
+ */
+function createImportRemovalEdit(
+	rootNode: SgNode<Python>,
+	remainingToolNodeUsages: number,
+): Edit | null {
+	if (remainingToolNodeUsages > 0) {
+		return null;
+	}
+
+	// Find import statements that import ToolNode
+	const imports = rootNode.findAll({
+		rule: {
+			kind: "import_from_statement",
+		},
+	});
+
+	for (const importStmt of imports) {
+		const importText = importStmt.text();
+
+		// Check if this import includes ToolNode
+		if (!importText.includes("ToolNode")) continue;
+
+		// Find the dotted_name nodes that are imported names (not module name)
+		const importedNames = importStmt.findAll({
+			rule: {
+				kind: "dotted_name",
+				has: {
+					kind: "identifier",
+					regex: "^ToolNode$",
+				},
+			},
+		});
+
+		// Find the ToolNode identifier specifically
+		for (const nameNode of importedNames) {
+			// Make sure this is an imported name, not part of the module path
+			// by checking it's not the module_name field
+			const moduleNameNode = importStmt.find({
+				rule: {
+					kind: "dotted_name",
+					inside: {
+						kind: "import_from_statement",
+						field: "module_name",
+					},
+				},
+			});
+
+			// Skip if this is the module name
+			if (moduleNameNode && moduleNameNode.id() === nameNode.id()) {
+				continue;
+			}
+
+			// Count all imported names in this statement
+			const allImportedNames: SgNode<Python>[] = [];
+			const children = importStmt.children();
+			let foundImportKeyword = false;
+
+			for (const child of children) {
+				if (child.kind() === "import") {
+					foundImportKeyword = true;
+					continue;
+				}
+				if (foundImportKeyword && child.kind() === "dotted_name") {
+					allImportedNames.push(child);
+				}
+			}
+
+			if (allImportedNames.length === 1) {
+				// Only ToolNode is imported - remove entire import statement
+				const startPos = importStmt.range().start.index;
+				let endPos = importStmt.range().end.index;
+
+				// Include exactly one newline after the import (if present)
+				// to avoid leaving blank lines, but preserve remaining structure
+				const fullText = rootNode.text();
+				if (endPos < fullText.length && fullText[endPos] === "\n") {
+					endPos++;
+					// If there's a second newline (blank line), consume it too
+					// but only if there was already a blank line there
+					if (endPos < fullText.length && fullText[endPos] === "\n") {
+						endPos++;
+					}
+				}
+
+				return {
+					startPos,
+					endPos,
+					insertedText: "",
+				};
+			} else {
+				// Multiple imports - remove just ToolNode and associated comma
+				const toolNodeIdentifier = nameNode.find({
+					rule: {
+						kind: "identifier",
+						regex: "^ToolNode$",
+					},
+				});
+
+				if (!toolNodeIdentifier) continue;
+
+				// Find the range of "ToolNode" including surrounding comma and space
+				const fullText = rootNode.text();
+				let startPos = nameNode.range().start.index;
+				let endPos = nameNode.range().end.index;
+
+				// Check for comma before (", ToolNode")
+				let lookBehind = startPos - 1;
+				while (lookBehind >= 0 && fullText[lookBehind] === " ") {
+					lookBehind--;
+				}
+				if (lookBehind >= 0 && fullText[lookBehind] === ",") {
+					startPos = lookBehind;
+				} else {
+					// Check for comma after ("ToolNode, ")
+					let lookAhead = endPos;
+					while (lookAhead < fullText.length && fullText[lookAhead] === " ") {
+						lookAhead++;
+					}
+					if (lookAhead < fullText.length && fullText[lookAhead] === ",") {
+						endPos = lookAhead + 1;
+						// Also consume trailing space
+						while (endPos < fullText.length && fullText[endPos] === " ") {
+							endPos++;
+						}
+					}
+				}
+
+				return {
+					startPos,
+					endPos,
+					insertedText: "",
+				};
+			}
+		}
+	}
+
+	return null;
+}
+
+async function transform(root: SgRoot<Python>): Promise<string | null> {
+	const rootNode = root.root();
+	const edits: Edit[] = [];
+
+	// Track how many ToolNode usages we transform (to know if import can be removed)
+	let transformedToolNodeCount = 0;
+
+	// Find all agent creation calls
+	const agentCalls = rootNode.findAll({
+		rule: {
+			kind: "call",
+		},
+	});
+
+	for (const call of agentCalls) {
+		if (!isAgentCreationCall(call)) continue;
+
+		const match = findToolsArgWithToolNode(call);
+		if (!match) continue;
+
+		const { toolNodeCall } = match;
+		const innerArg = getSingleArgument(toolNodeCall);
+
+		if (!innerArg) continue;
+
+		// Replace ToolNode(ARG) with just ARG
+		edits.push(toolNodeCall.replace(innerArg.text()));
+		transformedToolNodeCount++;
+	}
+
+	if (edits.length === 0) {
+		return null;
+	}
+
+	// Calculate remaining ToolNode usages after transformation
+	const totalToolNodeUsages = countToolNodeUsages(rootNode);
+	const remainingUsages = totalToolNodeUsages - transformedToolNodeCount;
+
+	// Try to create import removal edit
+	const importEdit = createImportRemovalEdit(rootNode, remainingUsages);
+	if (importEdit) {
+		edits.push(importEdit);
+	}
+
+	return rootNode.commitEdits(edits);
+}
+
+export default transform;
+

--- a/codemods/unwrap-tool-node-in-agent/tests/basic-transform/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/basic-transform/expected.py
@@ -1,0 +1,4 @@
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(model="gpt-4o", tools=[check_weather, search_web])
+

--- a/codemods/unwrap-tool-node-in-agent/tests/basic-transform/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/basic-transform/input.py
@@ -1,0 +1,4 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+agent = create_react_agent(model="gpt-4o", tools=ToolNode([check_weather, search_web]))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/create-agent-function/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/create-agent-function/expected.py
@@ -1,0 +1,3 @@
+from langchain.agents import create_agent
+agent = create_agent(model="gpt-4o", tools=[my_tool])
+

--- a/codemods/unwrap-tool-node-in-agent/tests/create-agent-function/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/create-agent-function/input.py
@@ -1,0 +1,5 @@
+from langchain.agents import create_agent
+from langgraph.prebuilt import ToolNode
+
+agent = create_agent(model="gpt-4o", tools=ToolNode([my_tool]))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/keep-used-import/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/keep-used-import/expected.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+agent = create_react_agent(model="gpt-4o", tools=[check_weather])
+
+other_node = ToolNode([some_other_tool])

--- a/codemods/unwrap-tool-node-in-agent/tests/keep-used-import/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/keep-used-import/input.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+agent = create_react_agent(model="gpt-4o", tools=ToolNode([check_weather]))
+
+other_node = ToolNode([some_other_tool])

--- a/codemods/unwrap-tool-node-in-agent/tests/multiple-args-skip/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/multiple-args-skip/expected.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+# Should NOT transform - ToolNode has multiple args (likely custom config)
+agent = create_react_agent(model="gpt-4o", tools=ToolNode([my_tool], handle_tool_errors=True))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/multiple-args-skip/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/multiple-args-skip/input.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+# Should NOT transform - ToolNode has multiple args (likely custom config)
+agent = create_react_agent(model="gpt-4o", tools=ToolNode([my_tool], handle_tool_errors=True))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/qualified-toolnode/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/qualified-toolnode/expected.py
@@ -1,0 +1,4 @@
+import langgraph.prebuilt
+
+agent = langgraph.prebuilt.create_react_agent(model="gpt-4o", tools=[my_tool])
+

--- a/codemods/unwrap-tool-node-in-agent/tests/qualified-toolnode/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/qualified-toolnode/input.py
@@ -1,0 +1,4 @@
+import langgraph.prebuilt
+
+agent = langgraph.prebuilt.create_react_agent(model="gpt-4o", tools=langgraph.prebuilt.ToolNode([my_tool]))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/remove-unused-import/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/remove-unused-import/expected.py
@@ -1,0 +1,4 @@
+from langchain.agents import create_agent
+
+agent = create_agent(model="gpt-4o", tools=[check_weather])
+

--- a/codemods/unwrap-tool-node-in-agent/tests/remove-unused-import/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/remove-unused-import/input.py
@@ -1,0 +1,6 @@
+from langgraph.prebuilt import ToolNode
+
+from langchain.agents import create_agent
+
+agent = create_agent(model="gpt-4o", tools=ToolNode([check_weather]))
+

--- a/codemods/unwrap-tool-node-in-agent/tests/variable-toolnode/expected.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/variable-toolnode/expected.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent
+
+my_tools = [check_weather, search_web]
+agent = create_react_agent(model="gpt-4o", tools=my_tools)
+

--- a/codemods/unwrap-tool-node-in-agent/tests/variable-toolnode/input.py
+++ b/codemods/unwrap-tool-node-in-agent/tests/variable-toolnode/input.py
@@ -1,0 +1,5 @@
+from langgraph.prebuilt import create_react_agent, ToolNode
+
+my_tools = [check_weather, search_web]
+agent = create_react_agent(model="gpt-4o", tools=ToolNode(my_tools))
+

--- a/codemods/unwrap-tool-node-in-agent/tsconfig.json
+++ b/codemods/unwrap-tool-node-in-agent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true
+	},
+	"include": ["scripts/**/*.ts"]
+}
+

--- a/codemods/unwrap-tool-node-in-agent/workflow.yaml
+++ b/codemods/unwrap-tool-node-in-agent/workflow.yaml
@@ -1,0 +1,12 @@
+version: "1"
+
+nodes:
+  - id: apply-transforms
+    name: Unwrap ToolNode in create_agent/create_react_agent calls
+    type: automatic
+    steps:
+      - name: "Scan Python files and apply fixes"
+        js-ast-grep:
+          js_file: scripts/codemod.ts
+          language: "python"
+


### PR DESCRIPTION
## Summary

In LangGraph v1, `create_agent(...)` and `create_react_agent(...)` no longer accept `ToolNode` instances for the `tools` parameter; they must receive a list of tools directly.

This codemod transforms `tools=ToolNode(ARG)` to `tools=ARG` in agent creation calls.

## Detection Criteria

- Find calls to `create_agent(...)` or `create_react_agent(...)`
- Within those calls, find `tools=ToolNode(ARG)` (including qualified `langgraph.prebuilt.ToolNode`)
- Confirm `ToolNode` is used as the value of the `tools` keyword
- Only transform when `ToolNode(...)` wraps a single argument

## Transformation Logic

1. Replace `tools=ToolNode(ARG)` with `tools=ARG`
2. If `ToolNode` becomes unused in imports, remove it from the import list

## Before / After Example

```python
# Before
from langgraph.prebuilt import create_react_agent, ToolNode

agent = create_react_agent(model="gpt-4o", tools=ToolNode([check_weather, search_web]))
```

```python
# After
from langgraph.prebuilt import create_react_agent

agent = create_react_agent(model="gpt-4o", tools=[check_weather, search_web])
```

## Test Cases (7 passing)

| Test | Description |
|------|-------------|
| basic-transform | Basic transformation with import removal |
| qualified-toolnode | Handles `langgraph.prebuilt.ToolNode(...)` |
| multiple-args-skip | Skips when ToolNode has multiple args (custom config) |
| remove-unused-import | Removes ToolNode from imports when unused |
| keep-used-import | Keeps ToolNode import when still used elsewhere |
| variable-toolnode | Handles `ToolNode(my_tools)` variable arguments |
| create-agent-function | Works with `create_agent` function |

## Edge Cases

- **Multiple args/kwargs**: If `ToolNode(...)` has multiple arguments (e.g., `ToolNode([tools], handle_tool_errors=True)`), the transformation is skipped as this likely indicates custom error handling or configuration